### PR TITLE
add function to expand `alias`s in ast

### DIFF
--- a/lib/ethyl/lint.ex
+++ b/lib/ethyl/lint.ex
@@ -2,4 +2,48 @@ defmodule Ethyl.Lint do
   @moduledoc """
   Functions for linting Ethyl code
   """
+
+  @doc false
+  # strip the AST of all aliases
+  # this must be performed as a pre-processing step in order to properly
+  # identify which modules/functions/arities are being called
+  def expand_aliases(ast) do
+    {ast, _aliases} = Macro.postwalk(ast, [], &do_expand_aliases/2)
+    ast
+  end
+
+  defp do_expand_aliases(ast, aliases)
+
+  # alias/2
+  defp do_expand_aliases({:alias, _, [module, [as: alias]]}, aliases) do
+    {:ok, [{strip_alias_tag(alias), strip_alias_tag(module)} | aliases]}
+  end
+
+  # alias/1
+  defp do_expand_aliases({:alias, _, [{:__aliases__, _, module_path}]}, aliases) do
+    {:ok, [{Enum.take(module_path, -1), module_path} | aliases]}
+  end
+
+  defp do_expand_aliases({:__aliases__, meta, path}, aliases) do
+    {{:__aliases__, meta, expand_alias(path, aliases)}, aliases}
+  end
+
+  defp do_expand_aliases(ast, aliases), do: {ast, aliases}
+
+  defp expand_alias(module_path, aliases) do
+    Enum.reduce(aliases, module_path, fn {alias, expanded}, module_path ->
+      case sublist_rest(alias, module_path) do
+        {:ok, rest} -> expanded ++ rest
+        :error -> module_path
+      end
+    end)
+  end
+
+  # is as an ordered subset of bs? if so, return {:ok, rest_bs} else :error
+  defp sublist_rest(as, bs)
+  defp sublist_rest([e | as], [e | bs]), do: sublist_rest(as, bs)
+  defp sublist_rest([], bs), do: {:ok, bs}
+  defp sublist_rest(_as, _bs), do: :error
+
+  defp strip_alias_tag({:__aliases__, _meta, module_path}), do: module_path
 end

--- a/test/ethyl/lint_test.exs
+++ b/test/ethyl/lint_test.exs
@@ -1,0 +1,79 @@
+defmodule Ethyl.LintTest do
+  use ExUnit.Case, async: true
+
+  defmacrop assert_expanded(lhs, do: rhs) do
+    quote do
+      lhs =
+        unquote(lhs)
+        |> Ethyl.Lint.expand_aliases()
+        |> strip_meta()
+
+      rhs = strip_meta(unquote(Macro.escape(rhs)))
+
+      assert lhs == rhs
+    end
+  end
+
+  describe "expand_aliases/1 correctly expands" do
+    test "given a simple fixture using alias/1" do
+      fixture =
+        quote do
+          alias File.Stream
+          Stream.foo()
+        end
+
+      assert_expanded fixture do
+        :ok
+        File.Stream.foo()
+      end
+    end
+
+    test "given a simple fixture using alias/2" do
+      fixture =
+        quote do
+          alias Application, as: App
+          App.foo()
+        end
+
+      assert_expanded fixture do
+        :ok
+        Application.foo()
+      end
+    end
+
+    test "given a fixture that aliases multiple times" do
+      fixture =
+        quote do
+          alias Foo, as: F
+          alias F, as: B
+          B.foo()
+        end
+
+      assert_expanded fixture do
+        :ok
+        :ok
+        Foo.foo()
+      end
+    end
+
+    test "given a fixture that does nested aliasing" do
+      fixture =
+        quote do
+          alias Foo, as: F
+          alias F.Bar, as: B
+          B.foo()
+        end
+
+      assert_expanded fixture do
+        :ok
+        :ok
+        Foo.Bar.foo()
+      end
+    end
+  end
+
+  defp strip_meta(ast)
+  defp strip_meta({a, _meta, b}), do: {strip_meta(a), [], strip_meta(b)}
+  defp strip_meta(nodes) when is_list(nodes), do: Enum.map(nodes, &strip_meta/1)
+  defp strip_meta(ast), do: ast
+end

--- a/test/ethyl/lint_test.exs
+++ b/test/ethyl/lint_test.exs
@@ -70,6 +70,21 @@ defmodule Ethyl.LintTest do
         Foo.Bar.foo()
       end
     end
+
+    test "given a fixture aliases multiple things to the same name" do
+      fixture =
+        quote do
+          alias Foo.Bar
+          alias Baz.Bar
+          Bar.foo()
+        end
+
+      assert_expanded fixture do
+        :ok
+        :ok
+        Baz.Bar.foo()
+      end
+    end
   end
 
   defp strip_meta(ast)


### PR DESCRIPTION
a little function to expand `alias`s in any given AST

expanding aliases allows us to determine what MFAs are being called at lint/evaluation time

this function does it by postwalking (depth-first-search where nodes are not revisited after being replaced) the AST and replacing any aliases with their full module paths

being able to accurately identify the MFAs being called is the first step to locking down the ability to call any function (i.e. if we want to limit programs from being able to run `File.stream!/1`, we first need to make sure you can't just do

```elixir
alias File, as: F
F.stream!(path)
```

.)