### PR TITLE
expand static apply/3 at preprocessing time

### DIFF
--- a/lib/ethyl.ex
+++ b/lib/ethyl.ex
@@ -27,6 +27,7 @@ defmodule Ethyl do
     |> AstTransforms.expand_aliases()
     |> AstTransforms.alter_compile_directives(context)
     |> AstTransforms.expand_imports()
+    |> AstTransforms.expand_apply_3()
   end
 
   @doc """

--- a/test/corpus/apply_banned_function.exs
+++ b/test/corpus/apply_banned_function.exs
@@ -1,0 +1,4 @@
+apply(DateTime, :utc_now, [])
+apply(:erlang, :binary_to_term, [<<>>])
+mod = DateTime
+apply(mod, :utc_now, [])

--- a/test/ethyl/lint_test.exs
+++ b/test/ethyl/lint_test.exs
@@ -36,5 +36,14 @@ defmodule Ethyl.LintTest do
       # note: later imports take precedence
       assert lint.description =~ "NaiveDateTime.utc_now/0"
     end
+
+    test "given a program uses apply/3 to get around banned functions" do
+      fixture = Source.new("test/corpus/apply_banned_function.exs")
+      assert [a, b, c] = Lint.lint(fixture)
+      assert a.description =~ "DateTime.utc_now/0"
+      assert b.description =~ ":erlang.binary_to_term/1"
+      # dynamic apply is not expanded, but caught by the linter
+      assert c.description =~ "Kernel.apply/3"
+    end
   end
 end


### PR DESCRIPTION
This makes `apply/3` effectively a macro. You can use `apply/3` to form function calls at preprocessing time if the module is visible to the macro, but you can't hide the module in a binding (see the fixture lines 3 & 4). Dynamic `apply/3` is then rejected by the allowlist of functions.

connects #2