### PR TITLE
implement a compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 - 2021-10-25
+
+### Added
+
+- Added a mix task to compile ethyl expressions
+
 ## 0.1.0 - 2021-10-06
 
 ### Added

--- a/lib/ethyl/compiler.ex
+++ b/lib/ethyl/compiler.ex
@@ -1,0 +1,124 @@
+defmodule Ethyl.Compiler do
+  @moduledoc false
+
+  @manifest_version 1
+
+  # functions to compile ethyl expressions into BEAM bytecode
+
+  def compile(manifest_path, srcs, dest, force?) do
+    if force?, do: reset(manifest_path, dest)
+
+    manifest = parse_manifest(manifest_path)
+
+    File.mkdir_p!(dest)
+
+    srcs
+    |> Enum.reduce(manifest, &compile_file(&1, &2, dest))
+    |> write_manifest(manifest_path, manifest)
+  end
+
+  defp compile_file(file, manifest, dest) do
+    %Ethyl.Context{id: module} = context = Ethyl.Context.from_filename(file)
+
+    {ast, manifest} =
+      file
+      |> File.read!()
+      |> Code.string_to_quoted!()
+      |> replace_imports_with_remote_calls(Path.dirname(file), dest, manifest)
+
+    ast = Ethyl.from_elixir_ast(ast, context)
+    hash = :erlang.md5(file)
+
+    unless Map.get(manifest, file) == hash do
+      :code.purge(module)
+      :code.delete(module)
+
+      ast =
+        quote do
+          defmodule unquote(module) do
+            def value do
+              unquote(ast)
+            end
+          end
+        end
+
+      [{^module, beam}] = Code.compile_quoted(ast, file)
+
+      File.write!(beam_path(module, dest), beam)
+    end
+
+    Map.put(manifest, file, hash)
+  end
+
+  # Replace all calls to import/1 (with binaries) with a call to the
+  # compiled module's value/0 callback
+  defp replace_imports_with_remote_calls(ast, path, dest, manifest) do
+    Macro.postwalk(ast, manifest, fn
+      {:import, _meta, [import_path]}, manifest ->
+        file =
+          path
+          |> Path.join(import_path)
+          |> Path.expand()
+
+        module = Ethyl.Context.id_for_filename(file)
+
+        ast =
+          quote do
+            unquote(Macro.escape(module)).value()
+          end
+
+        {ast, Map.merge(manifest, compile_file(file, manifest, dest))}
+
+      ast, manifest ->
+        {ast, manifest}
+    end)
+  end
+
+  defp parse_manifest(path) do
+    {@manifest_version, %{} = manifest} =
+      path |> File.read!() |> :erlang.binary_to_term()
+
+    manifest
+  rescue
+    _ -> %{}
+  end
+
+  defp write_manifest(manifest, path, old_manifest) do
+    newly_compiled =
+      Enum.reject(manifest, fn {file, hash} ->
+        Map.get(old_manifest, file) == hash
+      end)
+
+    case Enum.count(newly_compiled) do
+      0 ->
+        :ok
+
+      n ->
+        suffix = if n == 1, do: "", else: "s"
+        Mix.shell().info("Compiled #{n} file#{suffix} (.exs)")
+    end
+
+    File.mkdir_p!(Path.dirname(path))
+    data = :erlang.term_to_binary({@manifest_version, manifest}, [:compressed])
+    File.write!(path, data)
+  end
+
+  defp beam_path(module, dest_path) do
+    Path.join(dest_path, Atom.to_string(module) <> ".beam")
+  end
+
+  def reset(manifest_path, dest_path) do
+    manifest = parse_manifest(manifest_path)
+
+    manifest_path
+    |> parse_manifest
+    |> Enum.each(fn {file, _hash} ->
+      module = Ethyl.Context.id_for_filename(file)
+      File.rm(beam_path(module, dest_path))
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    write_manifest(%{}, manifest_path, manifest)
+  end
+end

--- a/lib/ethyl/context.ex
+++ b/lib/ethyl/context.ex
@@ -21,4 +21,19 @@ defmodule Ethyl.Context do
 
     %__MODULE__{id: id}
   end
+
+  # these are used internally by the compiler
+  @doc false
+  def from_filename(file) do
+    %__MODULE__{id: id_for_filename(file)}
+  end
+
+  @doc false
+  def id_for_filename(file) do
+    ["Ethyl", file]
+    |> Enum.map(&String.replace(&1, ".", "::"))
+    |> Enum.map(&String.replace(&1, "/", "|"))
+    |> Enum.join("::")
+    |> String.to_atom()
+  end
 end

--- a/lib/mix/tasks/compile.ethyl.ex
+++ b/lib/mix/tasks/compile.ethyl.ex
@@ -33,6 +33,10 @@ defmodule Mix.Tasks.Compile.Ethyl do
   end
 
   @impl Mix.Task.Compiler
+  # chaps-ignore-start
   def manifests, do: [manifest()]
-  def manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
+
+  # chaps-ignore-stop
+
+  defp manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
 end

--- a/lib/mix/tasks/compile.ethyl.ex
+++ b/lib/mix/tasks/compile.ethyl.ex
@@ -1,0 +1,81 @@
+defmodule Mix.Tasks.Compile.Ethyl do
+  use Mix.Task
+  @recursive true
+
+  @doc false
+  def run(_args) do
+    project = Mix.Project.config()
+    dest = Mix.Project.compile_path(project)
+    File.mkdir_p!(dest)
+
+    srcs =
+      List.wrap(project[:ethylc_globs] || "lib/**/*.exs")
+      |> Enum.flat_map(&Path.wildcard/1)
+
+    _ = Mix.Tasks.Ethyl.Lint.run(srcs)
+
+    srcs
+    |> length()
+    |> compile_message()
+    |> Mix.shell().info()
+
+    srcs
+    |> Task.async_stream(&compile_file(&1, dest), timeout: 20_000)
+    |> Stream.run()
+  end
+
+  defp compile_file(file, dest) do
+    context = Ethyl.Context.from_filename(file)
+
+    ast =
+      file
+      |> File.read!()
+      |> Code.string_to_quoted!()
+      |> replace_imports_with_remote_calls(Path.dirname(file), dest)
+      |> Ethyl.from_elixir_ast(context)
+
+    ast =
+      quote do
+        defmodule unquote(context.id) do
+          def value do
+            unquote(ast)
+          end
+        end
+      end
+
+    [{module, beam}] = Code.compile_quoted(ast, file)
+
+    file =
+      [dest, Atom.to_string(module) <> ".beam"]
+      |> Path.join()
+      |> File.open!([:write])
+
+    IO.binwrite(file, beam)
+  end
+
+  defp compile_message(1), do: "Compiling 1 file (.exs)"
+  defp compile_message(n), do: "Compiling #{n} files (.exs)"
+
+  # Replace all calls to import/1 (with binaries) with a call to the
+  # compiled module's value/0 callback
+  defp replace_imports_with_remote_calls(ast, path, dest) do
+    Macro.postwalk(ast, fn
+      {:import, _meta, [import_path]} ->
+        file =
+          path
+          |> Path.join(import_path)
+          |> Path.expand()
+
+        compile_file(file, dest)
+
+        module = Ethyl.Context.id_for_filename(file)
+    
+        quote do
+          unquote(Macro.escape(module)).value()
+        end
+
+      ast ->
+        ast
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,7 @@ defmodule Ethyl.MixProject do
       version: @version,
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
+      ethylc_globs: ["test/corpus/compile/*.exs"],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       test_coverage: [tool: Chaps],

--- a/test/corpus/compile/default.exs
+++ b/test/corpus/compile/default.exs
@@ -1,0 +1,3 @@
+math = import "./math.exs"
+
+math.add.(1, 2)

--- a/test/corpus/compile/math.exs
+++ b/test/corpus/compile/math.exs
@@ -1,0 +1,1 @@
+%{add: fn x, y -> x + y end}

--- a/test/mix/tasks/compile.ethyl_test.exs
+++ b/test/mix/tasks/compile.ethyl_test.exs
@@ -18,6 +18,10 @@ defmodule Mix.Tasks.Compile.EthylTest do
       |> Ethyl.Context.id_for_filename()
 
     assert module.value() == 3
+
+    # compiling again with --force recompiles all
+    assert Mix.Tasks.Compile.Ethyl.run(["--force"]) == :ok
+    assert_receive {:mix_shell, :info, ["Compiled 2 files (.exs)"]}
   end
 
   describe "given a corrupted manifest has been written" do

--- a/test/mix/tasks/compile.ethyl_test.exs
+++ b/test/mix/tasks/compile.ethyl_test.exs
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.Compile.EthylTest do
+  use ExUnit.Case
+
+  setup_all do
+    shell = Mix.shell()
+    Mix.shell(Mix.Shell.Process)
+    on_exit(fn -> Mix.shell(shell) end)
+  end
+
+  test "the compile task can be invoked to compile files into BEAM bytecode" do
+    assert Mix.Tasks.Compile.Ethyl.run(["--force"]) == :ok
+    assert_receive {:mix_shell, :info, ["Compiled 2 files (.exs)"]}
+
+    module =
+      ~w[test corpus compile default.exs]
+      |> Path.join()
+      |> Path.expand()
+      |> Ethyl.Context.id_for_filename()
+
+    assert module.value() == 3
+  end
+
+  describe "given a corrupted manifest has been written" do
+    setup do
+      path = Path.join(Mix.Project.manifest_path(), "compile.ethyl")
+      File.write!(path, <<0>>)
+    end
+
+    test "the compile task resets state" do
+      assert Mix.Tasks.Compile.Ethyl.run(["--force"]) == :ok
+      assert_receive {:mix_shell, :info, ["Compiled 2 files (.exs)"]}
+    end
+  end
+end


### PR DESCRIPTION
closes #4 

This PR adds a Mix task that compiles ethyl expressions as BEAM bytecode, allowing us to get coverage on ethyl expressions.

It's inspired mostly by the Mix tasks for the Elixir compiler but it's simpler because each expression file doesn't need to recompile if any other file changes (no global state :). (And by simpler, I mean that the check for if-thing-is-already-compiled uses an md5 comparison instead of mtime stuff.)

The basic idea is that you put your expression in a module:

```elixir
defmodule MyFakeModuleName do
  def value, do: unquote(expression goes here!)
end
```

And compile that module. Lo and behold, it is actually that simple and I now have coverage on some real-life expressions :tada: 

If you have a repository with a bunch of ethyl expressions in it and are using ExUnit to test the expressions, you can just add

```elixir
defmodule MyProject.MixProject do
  def project do
    [
      # ..
      compilers: Mix.compilers() ++ [:ethyl],
      # ..
    ]
  end
end
```

to make this compilation happen when you run `mix compile` (or other tasks that invoke the compile task), and :boom:, you'll be able to get coverage.

Plays well with `mix clean` and `mix compile --force` as well.